### PR TITLE
Switch turn type logic

### DIFF
--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -781,6 +781,8 @@ func CalculateStats(ps []Point, statType StatFlag, speedUnits UnitsFlag, prefere
 		windDir = autoDetectWindDir(ps, TurnJibe)
 	}
 
+	fmt.Printf("wind dir: %.3f\n", windDir)
+
 	// Calculate tackSide for each point.
 	// fmt.Printf("wind dir: %.3f\n", windDir)
 	for i := 1; i < len(ps); i++ {
@@ -1338,9 +1340,9 @@ func detectTurnTypeFromTurnHeading(heading float64, windDir float64) TurnType {
 	// minHeadingDiff: a minimum difference between exact upwind or downwind to recognize a turn type.
 	minHeadingDiff := 60.0
 	if diff < minHeadingDiff {
-		return TurnJibe
-	} else if diff > (180 - minHeadingDiff) {
 		return TurnTack
+	} else if diff > (180 - minHeadingDiff) {
+		return TurnJibe
 	}
 
 	return TurnUnknown


### PR DESCRIPTION
I found a bug in the turn type determination logic. The code was being executed twice, which accidentally produced a correct result for the turn type, but the wind direction ended up being determined incorrectly.

I reversed the logic for identifying a turn type, and now it works as intended. Specifically, when handling a tack, the angle difference between the movement direction and the wind must be less than the threshold, not the other way around. This also matches the function’s description.