### PR TITLE
Alpha 500 now use unknown and jibe turns

### DIFF
--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -916,6 +916,9 @@ func CalculateStats(ps []Point, statType StatFlag, speedUnits UnitsFlag, prefere
 						if res.wDirStats.alpha500m.speed < turnSubtrack.speed {
 							res.wDirStats.alpha500m = turnSubtrack
 						}
+						if res.alpha500m.speed < turnSubtrack.speed {
+							res.alpha500m = turnSubtrack
+						}
 					case TurnTack:
 						if res.wDirStats.delta500m.speed < turnSubtrack.speed {
 							res.wDirStats.delta500m = turnSubtrack


### PR DESCRIPTION
There was a bug with alpha 500 using only unknown turns. That didn't cause a problem when wind direction was not given, but was a problem when it was. Only unknown turns were counted toward alpha 500.